### PR TITLE
Handle inlineCode when it’s provided by the user

### DIFF
--- a/core/index.js
+++ b/core/index.js
@@ -37,24 +37,41 @@ function renderer (options) {
       props: options.props || {}
     })
 
-    const hast = toHAST(node, {
-      handlers: {
-        // Remove imports from output
-        import: () => {},
-        // Coerce the JSX node into a node structure that toHyper
-        // will accept. This will later be passed on to toElement
-        // for node rendering within the given scope.
-        jsx: (h, node) => {
-          return Object.assign({}, node, {
-            type: 'element',
-            tagName: 'jsx',
-            children: [{
-              type: 'text',
-              value: node.value
-            }]
-          })
-        }
+    const handlers = {
+      // Remove imports from output
+      import: () => {},       
+      // Coerce the JSX node into a node structure that toHyper
+      // will accept. This will later be passed on to toElement
+      // for node rendering within the given scope.
+      jsx: (h, node) => {
+        return Object.assign({}, node, {
+          type: 'element',
+          tagName: 'jsx',
+          children: [{
+            type: 'text',
+            value: node.value
+          }]
+        })
       }
+    }
+
+    // `inlineCode` gets passed as `code` by the HAST transform.
+    // This makes sure `inlineCode` is used when it's defined by the user
+    if(components.inlineCode) {
+      handlers.inlineCode = (h, node) => {
+        return Object.assign({}, node, {
+          type: 'element',
+          tagName: 'inlineCode',
+          children: [{
+            type: 'text',
+            value: node.value
+          }]
+        })
+      }
+    }
+
+    const hast = toHAST(node, {
+      handlers
     })
 
     return toHyper(el(scope), {


### PR DESCRIPTION
Fixes #70

Turns out the HAST transform indeed turns inlineCode into `code`. This adds support for the `inlineCode` property.
Maybe we can figure out something that allows `components` to be `MDXAST` nodes instead of HAST after this has been merged :+1: